### PR TITLE
default marker for mime.normalize

### DIFF
--- a/lib/resty/smtp/mime.lua
+++ b/lib/resty/smtp/mime.lua
@@ -92,6 +92,7 @@ wrap = choose(wrapt)
 
 -- define the end-of-line normalization filter
 function normalize(marker)
+    if not marker then marker = '\r\n' end
     return ltn12.filter.cycle(eol, 0, marker)
 end
 


### PR DESCRIPTION
The LuaSocket documentation states [marker defaults to CRLF](http://w3.impa.br/~diego/software/luasocket/mime.html#normalize).