### PR TITLE
fix use of arg in ltn12

### DIFF
--- a/lib/resty/smtp/ltn12.lua
+++ b/lib/resty/smtp/ltn12.lua
@@ -41,7 +41,8 @@ end
 -- chains a bunch of filters together
 -- (thanks to Wim Couwenberg)
 function filter.chain(...)
-    local n = table.getn(arg)
+    local arg = {...}
+    local n = #arg
     local top, index = 1, 1
     local retry = ""
     return function(chunk)
@@ -189,6 +190,7 @@ end
 -- other, as if they were concatenated
 -- (thanks to Wim Couwenberg)
 function source.cat(...)
+    local arg = {...}
     local src = table.remove(arg, 1)
     return function()
         while src do


### PR DESCRIPTION
I did the same commit [upstream years ago](https://github.com/diegonehab/luasocket/commit/ffddaf4a2e2c33f805ee072c6f78fe987fd35f87) :) This use of `arg` is actually not valid Lua since 5.1. It does work in 5.1, but only with 5.0 compatibility on.