### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Example
             subject= mime.ew(args.subject or config.mail.SUBJECT, nil,
                              { charset= "utf-8" }),
             ["content-transfer-encoding"]= "BASE64",
-            ["content-type"]= "text/plain; charset='utf-8'",
+            ["content-type"]= "text/plain; charset=utf-8",
         },
 
         body= mime.b64(args.body)


### PR DESCRIPTION
In case of single quotes around the encoding some email clients 
(for example mail.ru in the firefox and google chrome browser) 
show corrupted text instead utf-8 characters.