### PR TITLE
Fix chaos in UTF-8 encoding

### DIFF
--- a/lib/resty/smtp.lua
+++ b/lib/resty/smtp.lua
@@ -228,8 +228,7 @@ local function send_source(mesgt)
     -- make sure we have a content-type
     local headers = lower_headers(mesgt.headers or {})
 
-    headers["content-type"] = headers["content-type"] or
-        'text/plain; charset="iso-8859-1"'
+    headers["content-type"] = headers["content-type"] or 'text/html; charset="utf-8"'
 
     send_headers(headers)
 
@@ -248,8 +247,7 @@ local function send_string(mesgt)
     -- make sure we have a content-type
     local headers = lower_headers(mesgt.headers or {})
 
-    headers["content-type"] = headers["content-type"] or
-        'text/plain; charset="iso-8859-1"'
+    headers["content-type"] = headers["content-type"] or 'text/html; charset="utf-8"'
 
     send_headers(headers)
 


### PR DESCRIPTION
The best smtp server under openresty ever!
but we are encountered  chaos in Chinese UTF-8 encoding. We tried to append content-type in header section according to the code, but it won't work instead appending time-stamps.
We make this PR to fix this scenario that somebody step into as well.